### PR TITLE
Added a new note under Options for .NET Core 2.x

### DIFF
--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -102,6 +102,13 @@ Defines the value for the `$(VersionSuffix)` MSBuild property in the project.
 `-v|--verbosity <LEVEL>`
 
 Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+> [!NOTE]
+> Web projects are not packable by default. To ovverride the default behaviour, add the below property to your `csproj` file
+```xml
+<PropertyGroup>
+    <IsPackable>true</IsPackable>
+</PropertyGroup>
+```
 
 # [.NET Core 1.x](#tab/netcore1x)
 


### PR DESCRIPTION
## Summary
Web projects are not packable by default from .NET core 2.x. So, I added this under the options section as a note and also provided the code snippet to override this default behavior.
